### PR TITLE
Optical Flow and Lidar

### DIFF
--- a/src/main/target/SPEEDYBEEF7V2/target.h
+++ b/src/main/target/SPEEDYBEEF7V2/target.h
@@ -142,11 +142,11 @@
 #define WS2811_PIN PB0
 
 // ********** Optiical Flow adn Lidar **************
-
 #define USE_RANGEFINDER
 #define USE_RANGEFINDER_MSP
 #define USE_OPFLOW
 #define USE_OPFLOW_MSP
+
 
 
 #define DEFAULT_FEATURES            (FEATURE_TX_PROF_SEL | FEATURE_CURRENT_METER | FEATURE_TELEMETRY | FEATURE_VBAT | FEATURE_OSD | FEATURE_BLACKBOX)


### PR DESCRIPTION
This enable the Otical Flow and the lidar in SPEEDYBEEF7V2
adapt to the right UART port in the following command in CLI for activating (UART 5 in the example)
Tested with Matek 3901-L0X

serial 4 1 115200 115200 0 115200
set rangefinder_hardware = MSP
set opflow_hardware = MSP